### PR TITLE
Fix: Edit card styling and database update

### DIFF
--- a/src/pages/Assets.tsx
+++ b/src/pages/Assets.tsx
@@ -151,15 +151,30 @@ export default function Assets() {
     if (!editingAsset) return;
 
     const formData = new FormData(e.currentTarget);
+    const quantity = Number(formData.get('quantity'));
+    const price_per_unit = Number(formData.get('price-per-unit'));
+    const total_value = quantity * price_per_unit;
+
     const updatedAsset = {
       type: formData.get('asset-type') as string,
-      quantity: Number(formData.get('quantity')),
+      quantity,
       unit: formData.get('unit') as string,
-      price_per_unit: Number(formData.get('price-per-unit')),
+      price_per_unit,
+      total_value,
     };
 
-    await supabase.from('assets').update(updatedAsset).match({ id: editingAsset.id });
-    setAssets(assets.map(asset => (asset.id === editingAsset.id ? { ...asset, ...updatedAsset } : asset)));
+    const { data, error } = await supabase
+      .from('assets')
+      .update(updatedAsset)
+      .match({ id: editingAsset.id })
+      .select();
+
+    if (error) {
+      console.error('Error updating asset:', error);
+      return;
+    }
+
+    setAssets(assets.map(asset => (asset.id === editingAsset.id ? data[0] : asset)));
     setIsEditingAsset(false);
     setEditingAsset(null);
   };

--- a/src/pages/Debts.tsx
+++ b/src/pages/Debts.tsx
@@ -33,6 +33,13 @@ import {
 } from "@/components/ui/alert-dialog"
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { 
   CreditCard, 
   AlertTriangle, 
@@ -128,8 +135,18 @@ export default function Debts() {
       status: formData.get('status') as string,
     };
 
-    await supabase.from('debts').update(updatedDebt).match({ id: editingDebt.id });
-    setDebts(debts.map(debt => (debt.id === editingDebt.id ? { ...debt, ...updatedDebt } : debt)));
+    const { data, error } = await supabase
+      .from('debts')
+      .update(updatedDebt)
+      .match({ id: editingDebt.id })
+      .select();
+
+    if (error) {
+      console.error('Error updating debt:', error);
+      return;
+    }
+
+    setDebts(debts.map(debt => (debt.id === editingDebt.id ? data[0] : debt)));
     setIsEditingDebt(false);
     setEditingDebt(null);
   };
@@ -363,10 +380,15 @@ export default function Debts() {
                 </div>
                 <div>
                   <Label htmlFor="status">Status</Label>
-                  <select name="status" defaultValue={editingDebt.status}>
-                    <option value="pending">Pending</option>
-                    <option value="paid">Paid</option>
-                  </select>
+                  <Select name="status" defaultValue={editingDebt.status}>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select status" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="pending">Pending</SelectItem>
+                      <SelectItem value="paid">Paid</SelectItem>
+                    </SelectContent>
+                  </Select>
                 </div>
                 <div className="flex gap-2 justify-end">
                   <Button type="button" variant="outline" onClick={() => setIsEditingDebt(false)}>


### PR DESCRIPTION
- I replaced the plain HTML select with the `Select` component in the Edit Debt dialog to match your application's styling.
- I fixed a bug where the `total_value` of an asset was not being recalculated on edit.
- I fixed a bug where the local state was not being updated with the new data after a successful database update in both the Assets and Debts pages.
- I ensured that the data is being sent to the database correctly.