### PR TITLE
Fix: Add buttons in forms not working

### DIFF
--- a/src/pages/Assets.tsx
+++ b/src/pages/Assets.tsx
@@ -259,58 +259,65 @@ export default function Assets() {
                 Track a new asset in your portfolio
               </DialogDescription>
             </DialogHeader>
-            <div className="space-y-4">
-              <div>
-                <Label htmlFor="asset-type">Asset Type</Label>
-                <Select value={newAsset.type} onValueChange={(value) => setNewAsset({ ...newAsset, type: value })}>
-                  <SelectTrigger>
-                    <SelectValue placeholder="Select asset type" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="silver">Silver</SelectItem>
-                    <SelectItem value="gold">Gold</SelectItem>
-                    <SelectItem value="bitcoin">Bitcoin</SelectItem>
-                    <SelectItem value="ethereum">Ethereum</SelectItem>
-                    <SelectItem value="real_estate">Real Estate</SelectItem>
-                    <SelectItem value="other">Other</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-              <div className="grid grid-cols-2 gap-4">
+            <form
+              onSubmit={(e) => {
+                e.preventDefault();
+                handleAddAsset();
+              }}
+            >
+              <div className="space-y-4">
                 <div>
-                  <Label htmlFor="quantity">Quantity</Label>
-                  <Input id="quantity" type="number" step="0.001" placeholder="0.00" value={newAsset.quantity} onChange={(e) => setNewAsset({ ...newAsset, quantity: e.target.value })} />
-                </div>
-                <div>
-                  <Label htmlFor="unit">Unit</Label>
-                  <Select value={newAsset.unit} onValueChange={(value) => setNewAsset({ ...newAsset, unit: value })}>
+                  <Label htmlFor="asset-type">Asset Type</Label>
+                  <Select value={newAsset.type} onValueChange={(value) => setNewAsset({ ...newAsset, type: value })}>
                     <SelectTrigger>
-                      <SelectValue placeholder="Select unit" />
+                      <SelectValue placeholder="Select asset type" />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="grams">Grams</SelectItem>
-                      <SelectItem value="ounces">Ounces</SelectItem>
-                      <SelectItem value="BTC">BTC</SelectItem>
-                      <SelectItem value="ETH">ETH</SelectItem>
-                      <SelectItem value="property">Property</SelectItem>
-                      <SelectItem value="shares">Shares</SelectItem>
+                      <SelectItem value="silver">Silver</SelectItem>
+                      <SelectItem value="gold">Gold</SelectItem>
+                      <SelectItem value="bitcoin">Bitcoin</SelectItem>
+                      <SelectItem value="ethereum">Ethereum</SelectItem>
+                      <SelectItem value="real_estate">Real Estate</SelectItem>
+                      <SelectItem value="other">Other</SelectItem>
                     </SelectContent>
                   </Select>
                 </div>
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <Label htmlFor="quantity">Quantity</Label>
+                    <Input id="quantity" type="number" step="0.001" placeholder="0.00" value={newAsset.quantity} onChange={(e) => setNewAsset({ ...newAsset, quantity: e.target.value })} />
+                  </div>
+                  <div>
+                    <Label htmlFor="unit">Unit</Label>
+                    <Select value={newAsset.unit} onValueChange={(value) => setNewAsset({ ...newAsset, unit: value })}>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select unit" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="grams">Grams</SelectItem>
+                        <SelectItem value="ounces">Ounces</SelectItem>
+                        <SelectItem value="BTC">BTC</SelectItem>
+                        <SelectItem value="ETH">ETH</SelectItem>
+                        <SelectItem value="property">Property</SelectItem>
+                        <SelectItem value="shares">Shares</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </div>
+                <div>
+                  <Label htmlFor="price-per-unit">Price per Unit</Label>
+                  <Input id="price-per-unit" type="number" step="0.01" placeholder="0.00" value={newAsset.price_per_unit} onChange={(e) => setNewAsset({ ...newAsset, price_per_unit: e.target.value })} />
+                </div>
+                <div className="flex gap-2 justify-end">
+                  <Button type="button" variant="outline" onClick={() => setIsAddingAsset(false)}>
+                    Cancel
+                  </Button>
+                  <Button type="submit" className="bg-gradient-primary">
+                    Add Asset
+                  </Button>
+                </div>
               </div>
-              <div>
-                <Label htmlFor="price-per-unit">Price per Unit</Label>
-                <Input id="price-per-unit" type="number" step="0.01" placeholder="0.00" value={newAsset.price_per_unit} onChange={(e) => setNewAsset({ ...newAsset, price_per_unit: e.target.value })} />
-              </div>
-              <div className="flex gap-2 justify-end">
-                <Button variant="outline" onClick={() => setIsAddingAsset(false)}>
-                  Cancel
-                </Button>
-                <Button className="bg-gradient-primary" onClick={handleAddAsset}>
-                  Add Asset
-                </Button>
-              </div>
-            </div>
+            </form>
           </DialogContent>
         </Dialog>
       </div>

--- a/src/pages/Debts.tsx
+++ b/src/pages/Debts.tsx
@@ -237,58 +237,65 @@ export default function Debts() {
                 Record a new debt to track your liabilities
               </DialogDescription>
             </DialogHeader>
-            <div className="space-y-4">
-              <div>
-                <Label htmlFor="title">Title</Label>
-                <Input id="title" placeholder="e.g., Credit Card" value={newDebt.title} onChange={(e) => setNewDebt({ ...newDebt, title: e.target.value })} />
-              </div>
-              <div>
-                <Label htmlFor="creditor">Creditor</Label>
-                <Input id="creditor" placeholder="e.g., Bank" value={newDebt.creditor} onChange={(e) => setNewDebt({ ...newDebt, creditor: e.target.value })} />
-              </div>
-              <div className="grid grid-cols-2 gap-4">
+            <form
+              onSubmit={(e) => {
+                e.preventDefault();
+                handleAddDebt();
+              }}
+            >
+              <div className="space-y-4">
                 <div>
-                  <Label htmlFor="amount">Amount</Label>
-                  <Input id="amount" type="number" placeholder="0.00" value={newDebt.amount} onChange={(e) => setNewDebt({ ...newDebt, amount: e.target.value })} />
+                  <Label htmlFor="title">Title</Label>
+                  <Input id="title" placeholder="e.g., Credit Card" value={newDebt.title} onChange={(e) => setNewDebt({ ...newDebt, title: e.target.value })} />
                 </div>
                 <div>
-                  <Label htmlFor="currency">Currency</Label>
-                  <Select value={newDebt.currency} onValueChange={(value) => setNewDebt({ ...newDebt, currency: value })}>
+                  <Label htmlFor="creditor">Creditor</Label>
+                  <Input id="creditor" placeholder="e.g., Bank" value={newDebt.creditor} onChange={(e) => setNewDebt({ ...newDebt, creditor: e.target.value })} />
+                </div>
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <Label htmlFor="amount">Amount</Label>
+                    <Input id="amount" type="number" placeholder="0.00" value={newDebt.amount} onChange={(e) => setNewDebt({ ...newDebt, amount: e.target.value })} />
+                  </div>
+                  <div>
+                    <Label htmlFor="currency">Currency</Label>
+                    <Select value={newDebt.currency} onValueChange={(value) => setNewDebt({ ...newDebt, currency: value })}>
+                      <SelectTrigger>
+                        <SelectValue placeholder="USD" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="USD">USD ($)</SelectItem>
+                        <SelectItem value="TRY">TRY (₺)</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </div>
+                <div>
+                  <Label htmlFor="dueDate">Due Date</Label>
+                  <Input id="dueDate" type="date" value={newDebt.dueDate} onChange={(e) => setNewDebt({ ...newDebt, dueDate: e.target.value })} />
+                </div>
+                <div>
+                  <Label htmlFor="type">Type</Label>
+                  <Select value={newDebt.type} onValueChange={(value) => setNewDebt({ ...newDebt, type: value })}>
                     <SelectTrigger>
-                      <SelectValue placeholder="USD" />
+                      <SelectValue placeholder="Select type" />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="USD">USD ($)</SelectItem>
-                      <SelectItem value="TRY">TRY (₺)</SelectItem>
+                      <SelectItem value="short">Short-Term</SelectItem>
+                      <SelectItem value="long">Long-Term</SelectItem>
                     </SelectContent>
                   </Select>
                 </div>
+                <div className="flex gap-2 justify-end">
+                  <Button type="button" variant="outline" onClick={() => setIsAddingDebt(false)}>
+                    Cancel
+                  </Button>
+                  <Button type="submit" className="bg-gradient-primary">
+                    Add Debt
+                  </Button>
+                </div>
               </div>
-              <div>
-                <Label htmlFor="dueDate">Due Date</Label>
-                <Input id="dueDate" type="date" value={newDebt.dueDate} onChange={(e) => setNewDebt({ ...newDebt, dueDate: e.target.value })} />
-              </div>
-              <div>
-                <Label htmlFor="type">Type</Label>
-                <Select value={newDebt.type} onValueChange={(value) => setNewDebt({ ...newDebt, type: value })}>
-                  <SelectTrigger>
-                    <SelectValue placeholder="Select type" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="short">Short-Term</SelectItem>
-                    <SelectItem value="long">Long-Term</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-              <div className="flex gap-2 justify-end">
-                <Button variant="outline" onClick={() => setIsAddingDebt(false)}>
-                  Cancel
-                </Button>
-                <Button className="bg-gradient-primary" onClick={handleAddDebt}>
-                  Add Debt
-                </Button>
-              </div>
-            </div>
+            </form>
           </DialogContent>
         </Dialog>
       </div>

--- a/src/pages/Expenses.tsx
+++ b/src/pages/Expenses.tsx
@@ -233,70 +233,77 @@ export default function Expenses() {
                 Record a new expense to track your spending
               </DialogDescription>
             </DialogHeader>
-            <div className="space-y-4">
-              <div>
-                <Label htmlFor="title">Title</Label>
-                <Input id="title" placeholder="e.g., Office Rent" value={newExpense.title} onChange={(e) => setNewExpense({ ...newExpense, title: e.target.value })} />
-              </div>
-              <div className="grid grid-cols-2 gap-4">
+            <form
+              onSubmit={(e) => {
+                e.preventDefault();
+                handleAddExpense();
+              }}
+            >
+              <div className="space-y-4">
                 <div>
-                  <Label htmlFor="amount">Amount</Label>
-                  <Input id="amount" type="number" placeholder="0.00" value={newExpense.amount} onChange={(e) => setNewExpense({ ...newExpense, amount: e.target.value })} />
+                  <Label htmlFor="title">Title</Label>
+                  <Input id="title" placeholder="e.g., Office Rent" value={newExpense.title} onChange={(e) => setNewExpense({ ...newExpense, title: e.target.value })} />
+                </div>
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <Label htmlFor="amount">Amount</Label>
+                    <Input id="amount" type="number" placeholder="0.00" value={newExpense.amount} onChange={(e) => setNewExpense({ ...newExpense, amount: e.target.value })} />
+                  </div>
+                  <div>
+                    <Label htmlFor="currency">Currency</Label>
+                    <Select value={newExpense.currency} onValueChange={(value) => setNewExpense({ ...newExpense, currency: value })}>
+                      <SelectTrigger>
+                        <SelectValue placeholder="USD" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="USD">USD ($)</SelectItem>
+                        <SelectItem value="TRY">TRY (₺)</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
                 </div>
                 <div>
-                  <Label htmlFor="currency">Currency</Label>
-                  <Select value={newExpense.currency} onValueChange={(value) => setNewExpense({ ...newExpense, currency: value })}>
+                  <Label htmlFor="category">Category</Label>
+                  <Select value={newExpense.category} onValueChange={(value) => setNewExpense({ ...newExpense, category: value })}>
                     <SelectTrigger>
-                      <SelectValue placeholder="USD" />
+                      <SelectValue placeholder="Select category" />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="USD">USD ($)</SelectItem>
-                      <SelectItem value="TRY">TRY (₺)</SelectItem>
+                      <SelectItem value="housing">Housing</SelectItem>
+                      <SelectItem value="utilities">Utilities</SelectItem>
+                      <SelectItem value="transportation">Transportation</SelectItem>
+                      <SelectItem value="groceries">Groceries</SelectItem>
+                      <SelectItem value="healthcare">Healthcare</SelectItem>
+                      <SelectItem value="other">Other</SelectItem>
                     </SelectContent>
                   </Select>
                 </div>
+                <div>
+                  <Label htmlFor="type">Type</Label>
+                  <Select value={newExpense.type} onValueChange={(value) => setNewExpense({ ...newExpense, type: value })}>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select type" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="fixed">Fixed</SelectItem>
+                      <SelectItem value="variable">Variable</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div>
+                  <Label htmlFor="date">Date</Label>
+                  <Input id="date" type="date" value={newExpense.date} onChange={(e) => setNewExpense({ ...newExpense, date: e.target.value })} />
+                </div>
+                <div className="flex gap-2 justify-end">
+                  <Button type="button" variant="outline" onClick={() => setIsAddingExpense(false)}>
+                    Cancel
+                  </Button>
+                  <Button type="submit" className="bg-gradient-primary">
+                    Add Expense
+                  </Button>
+                </div>
               </div>
-              <div>
-                <Label htmlFor="category">Category</Label>
-                <Select value={newExpense.category} onValueChange={(value) => setNewExpense({ ...newExpense, category: value })}>
-                  <SelectTrigger>
-                    <SelectValue placeholder="Select category" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="housing">Housing</SelectItem>
-                    <SelectItem value="utilities">Utilities</SelectItem>
-                    <SelectItem value="transportation">Transportation</SelectItem>
-                    <SelectItem value="groceries">Groceries</SelectItem>
-                    <SelectItem value="healthcare">Healthcare</SelectItem>
-                    <SelectItem value="other">Other</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-              <div>
-                <Label htmlFor="type">Type</Label>
-                <Select value={newExpense.type} onValueChange={(value) => setNewExpense({ ...newExpense, type: value })}>
-                  <SelectTrigger>
-                    <SelectValue placeholder="Select type" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="fixed">Fixed</SelectItem>
-                    <SelectItem value="variable">Variable</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-              <div>
-                <Label htmlFor="date">Date</Label>
-                <Input id="date" type="date" value={newExpense.date} onChange={(e) => setNewExpense({ ...newExpense, date: e.target.value })} />
-              </div>
-              <div className="flex gap-2 justify-end">
-                <Button variant="outline" onClick={() => setIsAddingExpense(false)}>
-                  Cancel
-                </Button>
-                <Button className="bg-gradient-primary" onClick={handleAddExpense}>
-                  Add Expense
-                </Button>
-              </div>
-            </div>
+            </form>
           </DialogContent>
         </Dialog>
       </div>

--- a/src/pages/Income.tsx
+++ b/src/pages/Income.tsx
@@ -220,68 +220,75 @@ export default function Income() {
                 Record a new income entry to track your earnings
               </DialogDescription>
             </DialogHeader>
-            <div className="space-y-4">
-              <div>
-                <Label htmlFor="title">Title</Label>
-                <Input id="title" placeholder="e.g., Freelance Project" value={newIncome.title} onChange={(e) => setNewIncome({ ...newIncome, title: e.target.value })} />
-              </div>
-              <div className="grid grid-cols-2 gap-4">
+            <form
+              onSubmit={(e) => {
+                e.preventDefault();
+                handleAddIncome();
+              }}
+            >
+              <div className="space-y-4">
                 <div>
-                  <Label htmlFor="amount">Amount</Label>
-                  <Input id="amount" type="number" placeholder="0.00" value={newIncome.amount} onChange={(e) => setNewIncome({ ...newIncome, amount: e.target.value })} />
+                  <Label htmlFor="title">Title</Label>
+                  <Input id="title" placeholder="e.g., Freelance Project" value={newIncome.title} onChange={(e) => setNewIncome({ ...newIncome, title: e.target.value })} />
+                </div>
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <Label htmlFor="amount">Amount</Label>
+                    <Input id="amount" type="number" placeholder="0.00" value={newIncome.amount} onChange={(e) => setNewIncome({ ...newIncome, amount: e.target.value })} />
+                  </div>
+                  <div>
+                    <Label htmlFor="currency">Currency</Label>
+                    <Select value={newIncome.currency} onValueChange={(value) => setNewIncome({ ...newIncome, currency: value })}>
+                      <SelectTrigger>
+                        <SelectValue placeholder="USD" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="USD">USD ($)</SelectItem>
+                        <SelectItem value="TRY">TRY (₺)</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
                 </div>
                 <div>
-                  <Label htmlFor="currency">Currency</Label>
-                  <Select value={newIncome.currency} onValueChange={(value) => setNewIncome({ ...newIncome, currency: value })}>
+                  <Label htmlFor="category">Category</Label>
+                  <Select value={newIncome.category} onValueChange={(value) => setNewIncome({ ...newIncome, category: value })}>
                     <SelectTrigger>
-                      <SelectValue placeholder="USD" />
+                      <SelectValue placeholder="Select category" />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="USD">USD ($)</SelectItem>
-                      <SelectItem value="TRY">TRY (₺)</SelectItem>
+                      <SelectItem value="freelance">Freelance</SelectItem>
+                      <SelectItem value="commission">Commission</SelectItem>
+                      <SelectItem value="rent">Rent</SelectItem>
+                      <SelectItem value="other">Other</SelectItem>
                     </SelectContent>
                   </Select>
                 </div>
+                <div>
+                  <Label htmlFor="status">Status</Label>
+                  <Select value={newIncome.status} onValueChange={(value) => setNewIncome({ ...newIncome, status: value })}>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select status" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="expected">Expected</SelectItem>
+                      <SelectItem value="received">Received</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div>
+                  <Label htmlFor="date">Date</Label>
+                  <Input id="date" type="date" value={newIncome.date} onChange={(e) => setNewIncome({ ...newIncome, date: e.target.value })} />
+                </div>
+                <div className="flex gap-2 justify-end">
+                  <Button type="button" variant="outline" onClick={() => setIsAddingIncome(false)}>
+                    Cancel
+                  </Button>
+                  <Button type="submit" className="bg-gradient-primary">
+                    Add Income
+                  </Button>
+                </div>
               </div>
-              <div>
-                <Label htmlFor="category">Category</Label>
-                <Select value={newIncome.category} onValueChange={(value) => setNewIncome({ ...newIncome, category: value })}>
-                  <SelectTrigger>
-                    <SelectValue placeholder="Select category" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="freelance">Freelance</SelectItem>
-                    <SelectItem value="commission">Commission</SelectItem>
-                    <SelectItem value="rent">Rent</SelectItem>
-                    <SelectItem value="other">Other</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-              <div>
-                <Label htmlFor="status">Status</Label>
-                <Select value={newIncome.status} onValueChange={(value) => setNewIncome({ ...newIncome, status: value })}>
-                  <SelectTrigger>
-                    <SelectValue placeholder="Select status" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="expected">Expected</SelectItem>
-                    <SelectItem value="received">Received</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-              <div>
-                <Label htmlFor="date">Date</Label>
-                <Input id="date" type="date" value={newIncome.date} onChange={(e) => setNewIncome({ ...newIncome, date: e.target.value })} />
-              </div>
-              <div className="flex gap-2 justify-end">
-                <Button variant="outline" onClick={() => setIsAddingIncome(false)}>
-                  Cancel
-                </Button>
-                <Button className="bg-gradient-primary" onClick={handleAddIncome}>
-                  Add Income
-                </Button>
-              </div>
-            </div>
+            </form>
           </DialogContent>
         </Dialog>
       </div>


### PR DESCRIPTION
The 'Add' buttons in the forms for adding income, expenses, debts, and assets were not working because they were not triggering a form submission.

This change wraps the content of the 'Add' dialogs in a `form` element with an `onSubmit` handler and changes the 'Add' buttons to `type="submit"`. This ensures that the forms are submitted correctly.