### PR TITLE
Fix: Remove duplicate useState import in Debts.tsx

### DIFF
--- a/src/pages/Debts.tsx
+++ b/src/pages/Debts.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect } from "react";
-import { useState } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import { useCurrency } from "@/contexts/CurrencyContext";
 import { useFilteredData } from "@/hooks/useFilteredData";


### PR DESCRIPTION
This commit resolves a `SyntaxError: Cannot declare a const variable twice: 'useState'` by removing a redundant import of `useState` from the `react` package in the `src/pages/Debts.tsx` file.