### PR TITLE
fix: Add missing Switch import in Assets page

### DIFF
--- a/src/pages/Assets.tsx
+++ b/src/pages/Assets.tsx
@@ -13,6 +13,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Switch } from "@/components/ui/switch";
 import {
   Select,
   SelectContent,


### PR DESCRIPTION
The `Switch` component was being used in `src/pages/Assets.tsx` without being imported, causing a `ReferenceError: Can't find variable: Switch`.

This commit adds the missing import statement for the `Switch` component from `@/components/ui/switch`.